### PR TITLE
BOOL-1413: Fixed final occurrence not being calculated

### DIFF
--- a/lib/job/compute-next-run-at.ts
+++ b/lib/job/compute-next-run-at.ts
@@ -83,13 +83,8 @@ export const computeNextRunAt = function (this: Job): Job {
       }
 
       // If endDate is less than the nextDate, set nextDate to null to stop the job from running further
-      if (endDate) {
-        const endDateDate: Date = moment
-          .tz(moment(endDate).format("YYYY-MM-DD"), timezone!)
-          .toDate();
-        if (nextDate > endDateDate) {
-          nextDate = null;
-        }
+      if (endDate && nextDate > endDate) {
+        nextDate = null;
       }
 
       this.attrs.nextRunAt = nextDate;


### PR DESCRIPTION
BOOL-1413

Made the logic check the end date with the stored end date time instead of an end date with the time 00:00:00.

Before this fix the last occurrence date would fail to be calculated. This was because there existed a check to ensure the next occurrence date was before (inclusive) the end date with time 00:00:00. This was problematic because often the end date would have a time component, like 19:00:00, and the next occurrence would be before that time, like 14:00:00.