### PR TITLE
Made processJobs check if it is already running

### DIFF
--- a/lib/agenda/index.ts
+++ b/lib/agenda/index.ts
@@ -101,6 +101,7 @@ class Agenda extends EventEmitter {
   _collection!: Collection;
   _nextScanAt: any;
   _processInterval: any;
+  _processJobsRunning: boolean | undefined
 
   cancel!: typeof cancel;
   close!: typeof close;

--- a/lib/agenda/start.ts
+++ b/lib/agenda/start.ts
@@ -1,6 +1,6 @@
 import createDebugger from "debug";
 import { Agenda } from ".";
-import { processJobs } from "../utils";
+import { callProcessJobs } from "../utils";
 
 const debug = createDebugger("agenda:start");
 
@@ -23,8 +23,8 @@ export const start = async function (this: Agenda): Promise<void | unknown> {
     this._processEvery
   );
   this._processInterval = setInterval(
-    processJobs.bind(this),
+    callProcessJobs.bind(this),
     this._processEvery
   );
-  process.nextTick(processJobs.bind(this));
+  process.nextTick(callProcessJobs.bind(this));
 };

--- a/lib/utils/process-jobs.ts
+++ b/lib/utils/process-jobs.ts
@@ -5,6 +5,22 @@ import { Agenda } from "../agenda";
 
 const debug = createDebugger("agenda:internal:processJobs");
 
+export const callProcessJobs = async function(
+  this: Agenda,
+  extraJob: Job
+) {
+  // Check if another copy of this processJobs function has not completed yet, and setInterval has called processJobs again
+  if (this._processJobsRunning === true) {
+    debug("Another instance of processJobs is already running, exiting this instance")
+    return;
+  }
+  this._processJobsRunning = true;
+
+  processJobs.bind(this, extraJob);
+
+  this._processJobsRunning = false;
+}
+
 /**
  * Process methods for jobs
  * @param {Job} extraJob job to run immediately
@@ -18,6 +34,7 @@ export const processJobs = async function (
     extraJob?.attrs?.name ?? "unknownName",
     extraJob?.attrs?._id ?? "unknownId"
   );
+
   // Make sure an interval has actually been set
   // Prevents race condition with 'Agenda.stop' and already scheduled run
   if (!this._processInterval) {


### PR DESCRIPTION
This wraps the call to `processJobs` in a function which first checks if another instance of `processJobs` is running. If that other instance of `processJobs` is running then the new `processJobs` call immediately exits. Worst case this means `processJobs` skips one or to `processEvery` intervals.