### PR TITLE
Use a recurring timer instead of an interval for processJobs.

### DIFF
--- a/lib/agenda/index.ts
+++ b/lib/agenda/index.ts
@@ -100,7 +100,7 @@ class Agenda extends EventEmitter {
   _mdb!: MongoDb;
   _collection!: Collection;
   _nextScanAt: any;
-  _processInterval: any;
+  _processTimer: any;
 
   cancel!: typeof cancel;
   close!: typeof close;

--- a/lib/agenda/start.ts
+++ b/lib/agenda/start.ts
@@ -12,7 +12,7 @@ const debug = createDebugger("agenda:start");
  * @returns resolves if db set beforehand, returns undefined otherwise
  */
 export const start = async function (this: Agenda): Promise<void | unknown> {
-  if (this._processInterval) {
+  if (this._processTimer) {
     debug("Agenda.start was already called, ignoring");
     return this._ready;
   }
@@ -22,8 +22,8 @@ export const start = async function (this: Agenda): Promise<void | unknown> {
     "Agenda.start called, creating interval to call processJobs every [%dms]",
     this._processEvery
   );
-  this._processInterval = setInterval(
-    processJobs.bind(this),
+  this._processTimer = setTimer(
+    processJobsOnTimer.bind(this),
     this._processEvery
   );
   process.nextTick(processJobs.bind(this));

--- a/lib/agenda/stop.ts
+++ b/lib/agenda/stop.ts
@@ -43,7 +43,7 @@ export const stop = async function (this: Agenda): Promise<void> {
   };
 
   debug("Agenda.stop called, clearing interval for processJobs()");
-  clearInterval(this._processInterval);
-  this._processInterval = undefined;
+  clearTimeout(this._processTimeout);
+  this._processTimeout = undefined;
   return _unlockJobs();
 };


### PR DESCRIPTION
This allows us to delay the next run if the queries take longer than 5 seconds.

Note that this is completely untested; I don't know the build process for this, so it may very well even have syntax errors, and I suspect the date logic is wrong.  But it's short enough that I wanted to throw it together and get it out here as a suggestion; I or someone else can try to fix it up next week.